### PR TITLE
Fix problem related to comparing sneakers gem versions

### DIFF
--- a/lib/sneakers_packer/rpc_reply_subscriber.rb
+++ b/lib/sneakers_packer/rpc_reply_subscriber.rb
@@ -19,7 +19,7 @@ module SneakersPacker
 
     def initialize_reply_queue
       # ensure_connection
-      if Sneakers::VERSION >= "2.7.0"
+      if Gem::Version.new(Sneakers::VERSION) >= Gem::Version.new('2.7.0')
         @publisher.ensure_connection!
       else
         @publisher.instance_eval do


### PR DESCRIPTION
After upgrading the sneakers gem to version `2.12.0`, I encountered a deadlock error. Upon further investigation, I discovered that this issue is caused by the double-locking of the Mutex.

 A fix for this issue has already been implemented in sneakers packer version `0.3.0`, where it states that if the sneaker version is equal to or greater than `2.7.0`, then the `ensure_connection!` method should not be called within the `mutex.synchronize` block. So, the mutex won't be locked twice. This works perfectly.

However, the sneaker version comparison doesn't seem working. Please see the screenshot below:

<img width="802" alt="Screenshot 2023-01-23 at 12 41 37 PM" src="https://user-images.githubusercontent.com/4444916/214112107-8612306c-0de6-45a9-b7a4-0a3094bbaaee.png">

It always returns `false`, which is incorrect. The expected outcome here is `true`.

I have used the `Gem::Version` comparison to ensure the version comparison is right.